### PR TITLE
Allow scripts to be made that want to retrieve the output directory easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Sick of having unorganised repositories? Tired of specifying the directory?
 Get `gclone` today!
 
-## Example Usage
+## Example usage
 
-```
+```shell
 $ gclone https://github.com/scottgreenup/desktop.git
 $ cd ~/code/github.com/scottgreenup/desktop
 $ pwd
@@ -20,8 +20,55 @@ nothing to commit, working tree clean
 
 You can use it with args:
 
-```
+```shell
 $ gclone https://github.com/scottgreenup/desktop.git ./here -- --no-checkout
 git clone --no-checkout https://github.com/kubernetes/kubernetes.git here
 ...
 ```
+
+## Automatically change directory
+
+You can also create a script so you can enter the directory immediately.
+
+```shell
+$ cat ~/bin/gclone 
+#!/usr/bin/env bash
+
+cloned_directory=$(~/go/bin/gclone $@ | jq -r .targetDirectory)
+cd $cloned_directory
+```
+
+Ensure you have your `$PATH` setup to prioritise the bash script, then:
+
+```shell
+$ . gclone https://github.com/scottgreenup/desktop.git
+$ pwd
+/home/scottgreenup/code/github.com/scottgreenup/desktop
+```
+
+## Configuration
+
+You can configure `gclone` via a configuration file.
+
+* `$HOME/.config/gclone/config.json`
+* `$HOME/.config/gclone/config.yaml`
+* `/etc/gclone/config.json`
+* `/etc/gclone/config.yaml`
+
+### Configuration options
+
+#### DefaultDirectory
+
+Default value is `~/code`
+
+The default directory to clone into. Ensure it is created before using as
+`glone` will not create it for you.
+
+### Example configuration
+
+```json
+{
+  "DefaultDirectory": "~/dev/"
+}
+```
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,12 +91,12 @@ are cloned.`,
 		resp, err := RootCommandRun(result)
 
 		if err != nil {
-			fmt.Println("%s", err.Error())
+			fmt.Printf("%s", err.Error())
 			os.Exit(1)
 		}
 
 		if err := json.NewEncoder(os.Stdout).Encode(resp); err != nil {
-			fmt.Println("%s", err.Error())
+			fmt.Printf("%s", err.Error())
 		}
 	},
 }
@@ -119,6 +119,6 @@ func initConfig() {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file: ", viper.ConfigFileUsed())
+		_, _ = fmt.Fprintln(os.Stderr, "Using config file: ", viper.ConfigFileUsed())
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -12,13 +12,63 @@ import (
 	"github.com/spf13/viper"
 )
 
+type RootCommandOutput struct {
+	TargetDirectory string `json:"targetDirectory"`
+}
+
+func RootCommandRun(result *parse.TransformResult) (*RootCommandOutput, error) {
+
+	// Set up the `git clone` command.
+	gitArgs := result.GitArgs
+	_, _ = fmt.Fprintf(os.Stderr, "git clone %s\n", strings.Join(gitArgs, " "))
+	gitArgs = append([]string{"clone", "--progress"}, gitArgs...)
+	command := exec.Command("git", gitArgs...)
+
+	// Set up getting the output from `git clone`.
+	commandReader, err := command.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	// Run a goroutine to forward the command output.
+	go func() {
+		p := make([]byte, 1)
+		for {
+			_, err := commandReader.Read(p)
+
+			// TODO handle non io.EOF errors.
+			if err != nil {
+				break
+			}
+			_, _ = fmt.Fprintf(os.Stderr, "%s", string(p))
+		}
+	}()
+
+	// Run the command.
+	if err := command.Start(); err != nil {
+		return nil, err
+	}
+
+	// Wait for it to finish.
+	if err := command.Wait(); err != nil {
+		return nil, err
+	}
+
+	if err := os.Chdir(result.TargetDirectoryPath); err != nil {
+		return nil, err
+	}
+
+	return &RootCommandOutput{
+		TargetDirectory: result.TargetDirectoryPath,
+	}, nil
+}
+
 var rootCmd = &cobra.Command{
 	Use:   "gclone",
 	Short: "An improved git cloning experience",
 	Long: `A drop in replacement for git clone that allows for configuring the automatic organising of repositories that
 are cloned.`,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		transformConfig := parse.DefaultTransformConfig()
 		if s := viper.GetString("DefaultDirectory"); s != "" {
 			transformConfig.DefaultDirectory = s
@@ -28,7 +78,9 @@ are cloned.`,
 
 		if err != nil {
 			if err == parse.TransformErrorBadUsage {
-				cmd.Help()
+				if err := cmd.Help(); err != nil {
+					_, _ = fmt.Fprintln(os.Stderr, err)
+				}
 				os.Exit(1)
 			}
 
@@ -36,49 +88,16 @@ are cloned.`,
 			os.Exit(1)
 		}
 
-		gitArgs := result.GitArgs
+		resp, err := RootCommandRun(result)
 
-		fmt.Printf("git clone %s\n", strings.Join(gitArgs, " "))
-
-		gitArgs = append([]string{"clone", "--progress"}, gitArgs...)
-		command := exec.Command("git", gitArgs...)
-
-		commandReader, err := command.StderrPipe()
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+			fmt.Println("%s", err.Error())
 			os.Exit(1)
 		}
 
-		go func() {
-			p := make([]byte, 1)
-			for {
-				_, err := commandReader.Read(p)
-
-				if err != nil {
-					if err == io.EOF {
-						break
-					} else {
-						fmt.Fprintln(os.Stderr, err)
-						os.Exit(1)
-					}
-				}
-
-				fmt.Printf("%s", string(p))
-			}
-		}()
-
-		if err := command.Start(); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+		if err := json.NewEncoder(os.Stdout).Encode(resp); err != nil {
+			fmt.Println("%s", err.Error())
 		}
-
-		if err := command.Wait(); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-
-		fmt.Printf("\n%s\n", result.TargetDirectoryPath)
-
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/scottgreenup/gclone
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/pkg/errors v0.8.0
 	github.com/spf13/cobra v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
@@ -8,6 +10,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
@@ -41,6 +45,7 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a h1:1n5lsVfiQW3yfsRGu98756EH1
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/parse/transform.go
+++ b/pkg/parse/transform.go
@@ -61,7 +61,7 @@ func Transform(args []string, config TransformConfig) (*TransformResult, error) 
 		repo := ourArgs[0]
 		gu, err := git.NewURL(repo)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		// TODO normalise, spaces to -, etc...


### PR DESCRIPTION
I've modified `gclone` to output everything on `stderr` except for a JSON payload that is useful for scripts. In the future I think I will change this to be controlled be flags. Something like... you can have `--quiet` to remove the `git clone` output, `--json` for JSON only, maybe finer controls?